### PR TITLE
fix(security): only use shell:true on Windows

### DIFF
--- a/src/__tests__/opencode.test.ts
+++ b/src/__tests__/opencode.test.ts
@@ -160,7 +160,7 @@ describe("opencodeTool", () => {
         expect.any(Array),
         expect.objectContaining({
           stdio: ["ignore", "pipe", "pipe"],
-          shell: true,
+          shell: process.platform === "win32",
         })
       );
     });

--- a/src/__tests__/opencodeRespond.test.ts
+++ b/src/__tests__/opencodeRespond.test.ts
@@ -317,7 +317,7 @@ describe("opencodeRespondTool", () => {
         ["run", "--session", "mock-session-123", "--format", "json", "Yes, please continue"],
         expect.objectContaining({
           stdio: ["ignore", "pipe", "pipe"],
-          shell: true,
+          shell: process.platform === "win32",
         })
       );
     });

--- a/src/tools/opencode-respond.tool.ts
+++ b/src/tools/opencode-respond.tool.ts
@@ -79,7 +79,7 @@ function spawnOpenCodeRespondProcess(
   // Spawn the process
   const proc = spawn(CLI.COMMANDS.OPENCODE, args, {
     stdio: ["ignore", "pipe", "pipe"],
-    shell: true,
+    shell: process.platform === "win32",
   });
 
   activeRespondProcesses.set(taskId, proc);

--- a/src/tools/opencode.tool.ts
+++ b/src/tools/opencode.tool.ts
@@ -109,7 +109,7 @@ function spawnOpenCodeProcess(
   // Spawn the process
   const proc = spawn(CLI.COMMANDS.OPENCODE, args, {
     stdio: ["ignore", "pipe", "pipe"],
-    shell: true,
+    shell: process.platform === "win32",
   });
 
   activeProcesses.set(taskId, proc);

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -29,7 +29,7 @@ function executeCommandInternal(
 
     const childProcess = spawn(command, args, {
       env: process.env,
-      shell: true,
+      shell: process.platform === "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
 


### PR DESCRIPTION
Resolves DEP0190 deprecation warning on Linux/macOS by only enabling shell for Windows where .cmd wrapper is needed.

Closes #4